### PR TITLE
Undefined name: 'obj_' --> 'self._obj'

### DIFF
--- a/internetarchivepdf/pdfrenderer.py
+++ b/internetarchivepdf/pdfrenderer.py
@@ -391,7 +391,7 @@ class TessPDFRenderer(object):
         stream = bytes()
 
         if False: # if !textonly
-            xobject += b'/XObject << /Im1 ' + str((obj_ + 2)).encode('ascii') + b' 0 R >>\n'
+            xobject += b'/XObject << /Im1 ' + str((self._obj + 2)).encode('ascii') + b' 0 R >>\n'
 
         stream += (
           str(self._obj).encode('ascii') + b' 0 obj\n'

--- a/internetarchivepdf/pdfrenderer.py
+++ b/internetarchivepdf/pdfrenderer.py
@@ -526,7 +526,7 @@ def CodepointToUtf16be(code):
     res = None
 
     if (((code > 0xD7FF) and (code < 0xE000)) or (code > 0x10FFFF)):
-        tprintf("Dropping invalid codepoint %d\n", code);
+        print("Dropping invalid codepoint %d\n", code);
         return False, res
 
     if (code < 0x10000):


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./archive-pdf-tools/internetarchivepdf/pdfrenderer.py:394:52: F821 undefined name 'obj_'
            xobject += b'/XObject << /Im1 ' + str((obj_ + 2)).encode('ascii') + b' 0 R >>\n'
                                                   ^
./archive-pdf-tools/internetarchivepdf/pdfrenderer.py:529:9: F821 undefined name 'tprintf'
        tprintf("Dropping invalid codepoint %d\n", code);
        ^
2     F821 undefined name 'obj_'
2
```