### PR TITLE
Improve setup configuration (see #36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.egg-info
+**/__pycache__
+**.pyc
+docs/build/
+build/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+version = attr: internetarchivepdf.const.__version__
 name = archive-pdf-tools
 author = Merlijn Boris Wolf Wajer
 author_email = merlijn@archive.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,42 @@
 [metadata]
-description-file = README.rst
+name = archive-pdf-tools
+author = Merlijn Boris Wolf Wajer
+author_email = merlijn@archive.org
+description = Internet Archive PDF compression tools
+long_description = file: README.rst
+license = AGPL-3.0
+url = https://github.com/internetarchive/archive-pdf-tools
+keywords = PDF, MRC, hOCR, Internet Archive
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: GNU Affero General Public License v3
+    Programming Language :: Python :: 3
+
+[options]
+packages =
+    internetarchivepdf
+scripts =
+    bin/recode_pdf
+    tools/mrcview
+    tools/maskview
+    tools/pdfimagesmrc
+include_package_data = true
+zip_safe = false
+python_requires = >=3.6
+install_requires =
+    PyMuPDF >=1.19
+    Pillow >=8.3
+    archive_hocr_tools >=1.1.13
+    xmltodict >=0.12
+    roman >=3.3
+    numpy
+    lxml
+    scikit-image
+
+[options.package_data]
+internetarchivepdf = data/*
+
+[options.extras_require]
+docs =
+    sphinx >=3

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,7 @@ import numpy
 import os
 os.environ['CFLAGS'] = '-Ofast -DNPY_NO_DEPRECATED_API'
 
-main_ns = {}
-ver_path = convert_path('internetarchivepdf/const.py')
-with open(ver_path) as ver_file:
-    exec(ver_file.read(), main_ns)
-
-version = main_ns['__version__']
 setup(
-    version = version,
-    download_url = 'https://github.com/internetarchive/archive-pdf-tools/archive/%s.tar.gz' % version,
     include_dirs = [numpy.get_include()],
     ext_modules = cythonize(
         ['cython/sauvola.pyx', 'cython/optimiser.pyx'],

--- a/setup.py
+++ b/setup.py
@@ -14,39 +14,12 @@ with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 
 version = main_ns['__version__']
-setup(name='archive-pdf-tools',
-      version=version,
-      packages=['internetarchivepdf'],
-      description='Internet Archive PDF compression tools',
-      author='Merlijn Boris Wolf Wajer',
-      author_email='merlijn@archive.org',
-      url='https://github.com/internetarchive/archive-pdf-tools',
-      download_url='https://github.com/internetarchive/archive-pdf-tools/archive/%s.tar.gz' % version,
-        keywords=['PDF', 'MRC', 'hOCR', 'Internet Archive'],
-      license='AGPL-3.0',
-      scripts=['bin/recode_pdf', 'tools/mrcview', 'tools/maskview', 'tools/pdfimagesmrc'],
-      classifiers=[
-          'Development Status :: 3 - Alpha',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: GNU Affero General Public License v3',
-          'Programming Language :: Python :: 3',
-      ],
-      python_requires='>=3.6',
-      include_package_data=True,
-      package_data={'internetarchivepdf': ['data/*']},
-      include_dirs=[numpy.get_include()],
-      install_requires=[
-            'PyMuPDF==1.19.2',
-            'numpy',
-            'lxml',
-            'scikit-image',
-            'Pillow==8.3.2',
-            'roman==3.3',
-            'xmltodict==0.12.0',
-            'archive-hocr-tools==1.1.13',
-      ],
-      ext_modules=cythonize(['cython/sauvola.pyx', 'cython/optimiser.pyx'],
-        compiler_directives={'language_level' : '3'},
-      ),
-      zip_safe=False,
-      )
+setup(
+    version = version,
+    download_url = 'https://github.com/internetarchive/archive-pdf-tools/archive/%s.tar.gz' % version,
+    include_dirs = [numpy.get_include()],
+    ext_modules = cythonize(
+        ['cython/sauvola.pyx', 'cython/optimiser.pyx'],
+        compiler_directives = {'language_level' : '3'},
+    ),
+)


### PR DESCRIPTION
* Moved most configuration from `setup.py` to `setup.cfg`, but kept some things in `setup.py` where it makes sense
* Changed static requirements to more tolerant `>=`
* Added `extras_require` option, which means optional dependencies can now be installed using `pip3 install .[optional_group_name]`, in this case `pip3 install .[docs]`
* (Added git ignore rules)