### PR TITLE
Additional apt packages needed to build current jbig2enc on Ubuntu 22.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ First install dependencies. For example, in Ubuntu::
 
 
     sudo apt install libleptonica-dev libopenjp2-tools libxml2-dev libxslt-dev python3-dev python3-pip
+
+    sudo apt install automake libtool
     git clone https://github.com/agl/jbig2enc
     cd jbig2enc
     ./autogen.sh
@@ -85,7 +87,7 @@ Because `archive-pdf-tools` is on the `Python Package Index <https://pypi.org/pr
 
     # Latest version
     pip3 install archive-pdf-tools
-    
+
     # Specific version
     pip3 install archive-pdf-tools==1.4.14
 


### PR DESCRIPTION
I appreciated that the README gave ubuntu-specific instructions for dependencies, and instructions for building jbig2enc from source. (I am not very experienced at building things from source). 

I found a couple additional apt packages were necessary on Ubuntu 22.04, to have all tools needed to build `jbig2enc`. 

Without them, `./autogen.sh` produced errors:

* `./autogen.sh: 45: aclocal: not found`
* `./autogen.sh: 50: libtoolize: not found`

I thought it would be good to add these to README.  These dependencies are only necessary to build jbig2enc, not actually to run archive-pdf-tools once you have a built jbig2enc, so I put them on a separate line of `apt-get` to sort of imply that, although I don't know if more notes would be helpful. 